### PR TITLE
유저 기본 정보와 유저의 특성 정보 수정하는 컨트롤러 추가

### DIFF
--- a/src/Controller/Admin/User/admin.user.patch.controller.ts
+++ b/src/Controller/Admin/User/admin.user.patch.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Inject, Body, Patch } from "@nestjs/common";
+import { Controller, Inject, Body, Patch, Param } from "@nestjs/common";
 import { Roles } from "src/Security/Metadata";
 import { MongoUserUpdateService } from "src/Mongo";
 import { AuthService } from "src/Service";
@@ -10,12 +10,75 @@ import { UserType } from "src/Object/Enum";
  */
 @Controller("admin/users")
 export class AdminUserPatchController {
-  constructor() {}
+  constructor() { }
 
   @Inject()
   private readonly authService: AuthService;
   @Inject()
   private readonly mongoUserUpdateService: MongoUserUpdateService;
+
+  /**
+   * @author 승원
+   * 
+   * 특정 유저의 기본 정보와 특성 정보를 수정함
+   * 날짜와 관련된 정보가 바로 바로 수정되서 
+   * 클라이언트로 넘어오지 않음.
+   * DB에서는 수정된 정보가 존재함.
+   * 
+   */
+
+  @Roles(UserType.ADMIN)
+  @Patch(":userId")
+  async updateUser(
+    @Param("userId") userId: string,
+    @Body() body: {
+      nickname?: string;
+      email?: string;
+      gender?: string;
+      createdAt?: string;
+      birthday?: string;
+      credit?: number;
+    }) {
+
+    //return console.log(body)
+
+    const editUser = await this.mongoUserUpdateService.updateUser({
+      userId,
+      updateQuery: {
+        $set: {
+          nickname: body.nickname,
+          email: body.email,
+          createdAt: body.createdAt,
+          credit: body.credit
+        }
+      }
+    })
+
+    const editUserProperty = await this.mongoUserUpdateService.updateUserPropertyById({
+      userId,
+      updateQuery: {
+        $set: {
+          gender: body.gender,
+          birthday: body.birthday
+
+        }
+      }
+    })
+
+    const user = await Promise.all([editUser, editUserProperty]).then(
+      ([user, userProperty]) => {
+        return {
+          user,
+          userProperty
+        }
+      },
+    );
+
+    //console.log(user)
+
+    return user;
+
+  }
 
   /**
    * 다수 유저의 정보를 일괄적으로 변경합니다.


### PR DESCRIPTION
유저 생성 날짜와 생일 수정할 때, 업데이트 된 정보가 클라이언트로 바로 넘어오지 않음.
하지만 DB에는 문제없이 정보가 수정되어있음.
이 부분 추후에 살펴보고 수정해야 할 것 같음.